### PR TITLE
Remove distribute from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 beautifulsoup4==4.3.2
-distribute==0.6.24
 dumptruck==0.1.6
 lxml==3.3.5
 python-dateutil==2.2


### PR DESCRIPTION
This should fix the immediate problem you're seeing in https://github.com/openaustralia/morph/issues/870 and get your scraper all up and running again.

That line in the `requirements.txt` was causing the installation of libraries to fail, including beautiful soup. There is currently an open bug (https://github.com/openaustralia/morph/issues/589) which means that python compiles that fail don't register properly as being failed and so continue on their merry way.

The further impact of this is that the compile result actually gets cached because morph thinks it's successful and so the next time it gets run there's no compile message in the console at all which makes it all extremely confusing!
